### PR TITLE
Allow forge mods to access Bukkit plugin classes

### DIFF
--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
@@ -15,7 +15,7 @@ import org.bukkit.plugin.PluginDescriptionFile;
 /**
  * A ClassLoader for plugins, to allow shared classes across multiple plugins
  */
-final class PluginClassLoader extends URLClassLoader {
+public final class PluginClassLoader extends URLClassLoader {
     private final JavaPluginLoader loader;
     private final Map<String, Class<?>> classes = new HashMap<String, Class<?>>();
     private final PluginDescriptionFile description;


### PR DESCRIPTION
This should allow forge mods access to the Bukkit plugin classloader using Class.forName() and specifiying the classloader.

I'm pretty new to java, but without this it appears that a forge mod cannot access a bukkit plugins methods/classes event if they have no reference to bukkit in them whatsoever..

Picked this up when I was trying to integrate a plugin with a mod, *if*  the classes were available.

Let me know if this is not correct or has any consequences I am not aware of.